### PR TITLE
Feature - Random Password Generation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="https://img.shields.io/badge/Developed%20on-kali%20linux-blueviolet">  
 
 ## Purpose
-Psudohash is a password list generator for orchestrating brute force attacks and cracking hashes. It imitates certain password creation patterns commonly used by humans, like substituting a word's letters with symbols or numbers (leet), using char-case variations, adding a common padding before or after the main passphrase and more. It is keyword-based and highly customizable. 🎥 -> [Video Presentation](https://www.youtube.com/watch?v=oj3zjApOOGc) Psudohash also features single random password generation, able to generate random passwords in lowercase, uppercase, upper- and lowercase, and numeric, all with the option to add special characters. 
+Psudohash is a password list generator for orchestrating brute force attacks and cracking hashes. It imitates certain password creation patterns commonly used by humans, like substituting a word's letters with symbols or numbers (leet), using char-case variations, adding a common padding before or after the main passphrase and more. It is keyword-based and highly customizable. 🎥 -> [Video Presentation](https://www.youtube.com/watch?v=oj3zjApOOGc) Psudohash also features single random password generation, able to generate random alphanumeric passwords in lowercase, uppercase, upper- and lowercase, and solely numeric, all with the option to add special characters an at a specified length. 
 
 ## Pentesting Corporate Environments
 System administrators and other employees often use a mutated version of the Company's name to set passwords (e.g. Am@z0n_2022). This is commonly the case for network devices (Wi-Fi access points, switches, routers, etc), application or even domain accounts. With the most basic options, psudohash can generate a wordlist with all possible mutations of one or multiple keywords, based on common character substitution patterns (customizable), case variations, strings commonly used as padding and more. Take a look at the following example:  
@@ -50,12 +50,13 @@ chmod +x psudohash.py
 ./psudohash.py [-h] -w WORDS [-an LEVEL] [-nl LIMIT] [-y YEARS] [-ap VALUES] [-cpb] [-cpa] [-cpo] [-o FILENAME] [-q]
 
 # Random
-./psudohash.py [-ra] [-rua] [-rula] [-n] [-sc]
+./psudohash.py [-ra] [length] / [-rua] [length] / [-rula] [length] / [-n] [length] [-sc]
 ```
 The help dialog [ -h, --help ] includes usage details and examples.
 ## Usage Tips
 1. Combining options `--years` and `--append-numbering` with a `--numbering-limit` ≥ last two digits of any year input, will most likely produce duplicate words because of the mutation patterns implemented by the tool. 
 2. If you add custom padding values and/or modify the predefined common padding values in the source code, in combination with multiple optional parameters, there is a small chance of duplicate words occurring. psudohash includes word filtering controls but for speed's sake, those are limited.
+3. Default lengths for random passwords are 12 for all options except solely numeric, which is 9.
 
 ## Individuals
 When it comes to people, i think we all have (more or less) set passwords using a mutation of one or more words that mean something to us e.g., our name or wife/kid/pet/band names, sticking the year we were born at the end or maybe a super secure padding like "!@#". Well, guess what?

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="https://img.shields.io/badge/Developed%20on-kali%20linux-blueviolet">  
 
 ## Purpose
-Psudohash is a password list generator for orchestrating brute force attacks and cracking hashes. It imitates certain password creation patterns commonly used by humans, like substituting a word's letters with symbols or numbers (leet), using char-case variations, adding a common padding before or after the main passphrase and more. It is keyword-based and highly customizable. 🎥 -> [Video Presentation](https://www.youtube.com/watch?v=oj3zjApOOGc)
+Psudohash is a password list generator for orchestrating brute force attacks and cracking hashes. It imitates certain password creation patterns commonly used by humans, like substituting a word's letters with symbols or numbers (leet), using char-case variations, adding a common padding before or after the main passphrase and more. It is keyword-based and highly customizable. 🎥 -> [Video Presentation](https://www.youtube.com/watch?v=oj3zjApOOGc) Psudohash also features single random password generation, able to generate random passwords in lowercase, uppercase, upper- and lowercase, and numeric, all with the option to add special characters. 
 
 ## Pentesting Corporate Environments
 System administrators and other employees often use a mutated version of the Company's name to set passwords (e.g. Am@z0n_2022). This is commonly the case for network devices (Wi-Fi access points, switches, routers, etc), application or even domain accounts. With the most basic options, psudohash can generate a wordlist with all possible mutations of one or multiple keywords, based on common character substitution patterns (customizable), case variations, strings commonly used as padding and more. Take a look at the following example:  
@@ -46,7 +46,11 @@ chmod +x psudohash.py
 ```  
 ## Usage
 ```
+# Keywords
 ./psudohash.py [-h] -w WORDS [-an LEVEL] [-nl LIMIT] [-y YEARS] [-ap VALUES] [-cpb] [-cpa] [-cpo] [-o FILENAME] [-q]
+
+# Random
+./psudohash.py [-ra] [-rua] [-rula] [-n] [-sc]
 ```
 The help dialog [ -h, --help ] includes usage details and examples.
 ## Usage Tips

--- a/psudohash.py
+++ b/psudohash.py
@@ -3,7 +3,7 @@
 # Author: Panagiotis Chartas (t3l3machus)
 # https://github.com/t3l3machus
 
-import argparse, sys, itertools
+import argparse, sys, itertools, random
 
 # Colors
 MAIN = '\033[38;5;50m'
@@ -35,7 +35,7 @@ Usage examples:
 parser.add_argument("-ra", "--random-alphanumeric", action = "store_true", help = "Generate a single lowercase alphanumeric password")
 parser.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store_true", help = "Generate a single uppercase alphanumeric password")
 parser.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store_true", help = "Generate a single upper- and lowercase alphanumeric password")
-parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in the password") # TODO: may not use this
+#parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in the password") # TODO: may not use this
 parser.add_argument("-n", "--numbers", action = "store_true", help = "Generate a single password of 9 random digits")
 
 parser.add_argument("-w", "--words", action="store", help = "Comma seperated keywords to mutate")
@@ -154,21 +154,24 @@ mutations_cage = []
 basic_mutations = []
 outfile = args.output if args.output else 'output.txt'
 trans_keys = []
-random_sequence = []
+random_sequence = ""
 
-# If the user wants a random alphanumeric sequence, set the selection with appropriate characters
+# If the user wants a random alphanumeric password, set the selection with appropriate characters
 if not args.words:
 	if args.random_alphanumeric:
-		random_sequence = ["abcdefghijklmnopqrstuvwxyz1234567890"]
+		random_sequence = "abcdefghijklmnopqrstuvwxyz1234567890"
 
 	elif args.random_uppercase_alphanumeric:
-		random_sequence = ["ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"]
+		random_sequence = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
 	elif args.random_uppercase_lowercase_alphanumeric:
-		random_sequence = ["abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"]
+		random_sequence = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
 	elif args.numbers:
-		random_sequence = ["1234567890"]
+		random_sequence = "1234567890"
+
+	#if args.special_characters:
+	#	random_sequence += "~`! @#$%^&*()_-+={[}]|\:;\"'<,>.?/"
 
 transformations = [
 	{'a' : ['@', '4']},
@@ -518,6 +521,17 @@ def chill():
 
 
 
+def generate_random_password():
+	length = 12
+
+	# If the password is only numeric, set length to 9
+	if random_sequence.isnumeric():
+		length = 9
+	
+	pwd = ''.join(random.choice(random_sequence) for _ in range(length))
+	return pwd
+
+
 def main():
 	
 	banner() if not args.quiet else chill()
@@ -600,20 +614,35 @@ def main():
 				basic_mutations = []
 				mutations_cage = []
 				print(f' └─ Done!')
+
+				print(f'\n[{MAIN}Info{END}] Completed! List saved in {outfile}\n')
 			
-			print(f'\n[{MAIN}Info{END}] Completed! List saved in {outfile}\n')
+	else:
+		choice = ""
+		#special_chars = ""
+		if args.random_alphanumeric:
+			choice = "lowercase alphanumeric"
+
+		elif args.random_uppercase_alphanumeric:
+			choice = "uppercase alphanumeric"
+
+		elif args.random_uppercase_lowercase_alphanumeric:
+			choice = "uppercase and lowercase alphanumeric"
+
+		elif args.numbers:
+			choice = "numeric"
+
+		#if args.special_characters:
+		#	special_chars = f" with {GREEN}special characters{END}"
+
+		print(f'[{GREEN}*{END}] Generating random {GREEN}{choice}{END} password...')
+		with open(outfile, 'w') as output:
+			output.write(generate_random_password())
+
+		print(f' └─ Done!')
+		
+		print(f'\n[{MAIN}Info{END}] Completed! Password saved in {outfile}\n')
+
 	
-	elif args.random_alphanumeric:
-		pass
-
-	elif args.random_uppercase_alphanumeric:
-		pass
-
-	elif args.random_uppercase_lowercase_alphanumeric:
-		pass
-
-	elif args.numbers:
-		pass
-
 if __name__ == '__main__':
 	main()

--- a/psudohash.py
+++ b/psudohash.py
@@ -37,10 +37,10 @@ Usage examples:
 # Random generation flags do not conflict with keyword flags, and keyword flags are prioritized
 random_group = parser.add_mutually_exclusive_group()
 
-random_group.add_argument("-ra", "--random-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single lowercase alphanumeric password of specified length (default 12)")
-random_group.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single uppercase alphanumeric password of specified length (default 12)")
-random_group.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single upper- and lowercase alphanumeric password of specified length (default 12)")
-random_group.add_argument("-n", "--numbers", action = "store", type = int, nargs = "?", const = "9", help = "Generate a single random numeric of specified length (default 9)")
+random_group.add_argument("-ra", "--random-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single lowercase alphanumeric password of specified length (default 12, must be >= 1)")
+random_group.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single uppercase alphanumeric password of specified length (default 12, must be >= 1)")
+random_group.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single upper- and lowercase alphanumeric password of specified length (default 12, must be >= 1)")
+random_group.add_argument("-n", "--numbers", action = "store", type = int, nargs = "?", const = "9", help = "Generate a single random numeric of specified length (default 9, must be >= 1)")
 
 # Special characters flag does not interfere with other code.
 parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in any random password, does not work alone")
@@ -633,20 +633,44 @@ def main():
 		special_characters_message = ""
 
 		if args.random_alphanumeric:
+
 			choice = "lowercase alphanumeric"
-			password_length = args.random_alphanumeric
+
+			if args.random_alphanumeric < 1:
+				exit_with_msg("Random password length must be >= 1.")
+			else:
+				password_length = args.random_alphanumeric
+
 
 		elif args.random_uppercase_alphanumeric:
+
 			choice = "uppercase alphanumeric"
-			password_length = args.random_uppercase_alphanumeric
+
+			if args.random_uppercase_alphanumeric < 1:
+				exit_with_msg("Random password length must be >= 1.")
+			else:
+				password_length = args.random_uppercase_alphanumeric
+
 
 		elif args.random_uppercase_lowercase_alphanumeric:
+
 			choice = "uppercase and lowercase alphanumeric"
-			password_length = args.random_uppercase_lowercase_alphanumeric
+
+			if args.random_uppercase_lowercase_alphanumeric < 1:
+				exit_with_msg("Random password length must be >= 1.")
+			else:
+				password_length = args.random_uppercase_lowercase_alphanumeric
+
 
 		elif args.numbers:
+
 			choice = "numeric"
-			password_length = args.random_numbers
+
+			if args.numbers < 1:
+				exit_with_msg("Random password length must be >= 1.")
+			else:
+				password_length = args.numbers
+
 
 		if args.special_characters:
 			special_characters_message = f" with {GREEN}special characters{END}"

--- a/psudohash.py
+++ b/psudohash.py
@@ -25,20 +25,25 @@ Usage examples:
 
   Basic:
       python3 psudohash.py -w <keywords> -cpa
-	  python3 psudohash.py -ra -sc
+	  python3 psudohash.py -ra
 	
   Thorough:
       python3 psudohash.py -w <keywords> -cpa -an 3 -y 1990-2022
+	  python3 psudohash.py -rula 14 -sc
 '''
 	)
 
+# Prevent flags for random generation from being used together. 
+# Random generation flags do not conflict with keyword flags, and keyword flags are prioritized
 random_group = parser.add_mutually_exclusive_group()
 
-random_group.add_argument("-ra", "--random-alphanumeric", action = "store_true", help = "Generate a single lowercase alphanumeric password")
-random_group.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store_true", help = "Generate a single uppercase alphanumeric password")
-random_group.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store_true", help = "Generate a single upper- and lowercase alphanumeric password")
-random_group.add_argument("-n", "--numbers", action = "store_true", help = "Generate a single randoom numeric password of 9 digits")
-parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in random password")
+random_group.add_argument("-ra", "--random-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single lowercase alphanumeric password of specified length (default 12)")
+random_group.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single uppercase alphanumeric password of specified length (default 12)")
+random_group.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store", type = int, nargs = "?", const = "12", help = "Generate a single upper- and lowercase alphanumeric password of specified length (default 12)")
+random_group.add_argument("-n", "--numbers", action = "store", type = int, nargs = "?", const = "9", help = "Generate a single random numeric of specified length (default 9)")
+
+# Special characters flag does not interfere with other code.
+parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in any random password, does not work alone")
 
 parser.add_argument("-w", "--words", action="store", help = "Comma seperated keywords to mutate")
 parser.add_argument("-an", "--append-numbering", action="store", help = "Append numbering range at the end of each word mutation (before appending year or common paddings).\nThe LEVEL value represents the minimum number of digits. LEVEL must be >= 1. \nSet to 1 will append range: 1,2,3..100\nSet to 2 will append range: 01,02,03..100 + previous\nSet to 3 will append range: 001,002,003..100 + previous.\n\n", type = int, metavar='LEVEL')
@@ -172,7 +177,7 @@ if not args.words:
 		random_sequence = "1234567890"
 
 	if args.special_characters:
-		random_sequence += "~`! @#$%^&*()_-+={[}]|\:;\"'<,>.?/"
+		random_sequence += "~`!@#$%^&*()_-+={[}]|\:;\"'<,>.?/"
 
 transformations = [
 	{'a' : ['@', '4']},
@@ -522,14 +527,11 @@ def chill():
 
 
 
-def generate_random_password():
-	length = 12
+def generate_random_password(length: int):
 
-	# If the password is only numeric, set length to 9
-	if random_sequence.isnumeric():
-		length = 9
-	
+	# Randomly choose characters from the selection
 	pwd = ''.join(random.choice(random_sequence) for _ in range(length))
+
 	return pwd
 
 
@@ -620,26 +622,39 @@ def main():
 			
 	elif (args.random_alphanumeric or args.random_uppercase_alphanumeric 
 	or args.random_uppercase_lowercase_alphanumeric or args.numbers):
+		
+		# Determines message to print based on selected random option
 		choice = ""
+
+		# Desired password length
+		password_length = 0
+
+		# Displayed if special characters are included
 		special_characters_message = ""
+
 		if args.random_alphanumeric:
 			choice = "lowercase alphanumeric"
+			password_length = args.random_alphanumeric
 
 		elif args.random_uppercase_alphanumeric:
 			choice = "uppercase alphanumeric"
+			password_length = args.random_uppercase_alphanumeric
 
 		elif args.random_uppercase_lowercase_alphanumeric:
 			choice = "uppercase and lowercase alphanumeric"
+			password_length = args.random_uppercase_lowercase_alphanumeric
 
 		elif args.numbers:
 			choice = "numeric"
+			password_length = args.random_numbers
 
 		if args.special_characters:
 			special_characters_message = f" with {GREEN}special characters{END}"
 
-		print(f'[{GREEN}*{END}] Generating random {GREEN}{choice}{END} password{special_characters_message}...')
+		print(f'[{GREEN}*{END}] Generating random {GREEN}{choice}{END} password of length {GREEN}{password_length}{END}{special_characters_message}...')
+
 		with open(outfile, 'w') as output:
-			output.write(generate_random_password())
+			output.write(generate_random_password(password_length))
 
 		print(f' └─ Done!')
 		

--- a/psudohash.py
+++ b/psudohash.py
@@ -31,11 +31,10 @@ Usage examples:
 '''
 	)
 
-
 parser.add_argument("-ra", "--random-alphanumeric", action = "store_true", help = "Generate a single lowercase alphanumeric password")
 parser.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store_true", help = "Generate a single uppercase alphanumeric password")
 parser.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store_true", help = "Generate a single upper- and lowercase alphanumeric password")
-#parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in the password") # TODO: may not use this
+parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in the password")
 parser.add_argument("-n", "--numbers", action = "store_true", help = "Generate a single password of 9 random digits")
 
 parser.add_argument("-w", "--words", action="store", help = "Comma seperated keywords to mutate")
@@ -67,7 +66,6 @@ def unique(l):
 			unique_list.append(i)
     
 	return unique_list
-
 
 # Append numbering
 if args.numbering_limit and not args.append_numbering:
@@ -170,8 +168,8 @@ if not args.words:
 	elif args.numbers:
 		random_sequence = "1234567890"
 
-	#if args.special_characters:
-	#	random_sequence += "~`! @#$%^&*()_-+={[}]|\:;\"'<,>.?/"
+	if args.special_characters:
+		random_sequence += "~`! @#$%^&*()_-+={[}]|\:;\"'<,>.?/"
 
 transformations = [
 	{'a' : ['@', '4']},
@@ -615,11 +613,12 @@ def main():
 				mutations_cage = []
 				print(f' └─ Done!')
 
-				print(f'\n[{MAIN}Info{END}] Completed! List saved in {outfile}\n')
+			print(f'\n[{MAIN}Info{END}] Completed! List saved in {outfile}\n')
 			
-	else:
+	elif (args.random_alphanumeric or args.random_uppercase_alphanumeric 
+	or args.random_uppercase_lowercase_alphanumeric or args.numbers):
 		choice = ""
-		#special_chars = ""
+		special_characters_message = ""
 		if args.random_alphanumeric:
 			choice = "lowercase alphanumeric"
 
@@ -632,10 +631,10 @@ def main():
 		elif args.numbers:
 			choice = "numeric"
 
-		#if args.special_characters:
-		#	special_chars = f" with {GREEN}special characters{END}"
+		if args.special_characters:
+			special_characters_message = f" with {GREEN}special characters{END}"
 
-		print(f'[{GREEN}*{END}] Generating random {GREEN}{choice}{END} password...')
+		print(f'[{GREEN}*{END}] Generating random {GREEN}{choice}{END} password{special_characters_message}...')
 		with open(outfile, 'w') as output:
 			output.write(generate_random_password())
 

--- a/psudohash.py
+++ b/psudohash.py
@@ -25,6 +25,7 @@ Usage examples:
 
   Basic:
       python3 psudohash.py -w <keywords> -cpa
+	  python3 psudohash.py -ra -sc
 	
   Thorough:
       python3 psudohash.py -w <keywords> -cpa -an 3 -y 1990-2022
@@ -36,8 +37,8 @@ random_group = parser.add_mutually_exclusive_group()
 random_group.add_argument("-ra", "--random-alphanumeric", action = "store_true", help = "Generate a single lowercase alphanumeric password")
 random_group.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store_true", help = "Generate a single uppercase alphanumeric password")
 random_group.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store_true", help = "Generate a single upper- and lowercase alphanumeric password")
-random_group.add_argument("-n", "--numbers", action = "store_true", help = "Generate a single password of 9 random digits")
-parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in the password")
+random_group.add_argument("-n", "--numbers", action = "store_true", help = "Generate a single randoom numeric password of 9 digits")
+parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in random password")
 
 parser.add_argument("-w", "--words", action="store", help = "Comma seperated keywords to mutate")
 parser.add_argument("-an", "--append-numbering", action="store", help = "Append numbering range at the end of each word mutation (before appending year or common paddings).\nThe LEVEL value represents the minimum number of digits. LEVEL must be >= 1. \nSet to 1 will append range: 1,2,3..100\nSet to 2 will append range: 01,02,03..100 + previous\nSet to 3 will append range: 001,002,003..100 + previous.\n\n", type = int, metavar='LEVEL')

--- a/psudohash.py
+++ b/psudohash.py
@@ -31,13 +31,13 @@ Usage examples:
 '''
 	)
 
-'''
+
 parser.add_argument("-ra", "--random-alphanumeric", action = "store_true", help = "Generate a single lowercase alphanumeric password")
 parser.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store_true", help = "Generate a single uppercase alphanumeric password")
 parser.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store_true", help = "Generate a single upper- and lowercase alphanumeric password")
 parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in the password") # TODO: may not use this
 parser.add_argument("-n", "--numbers", action = "store_true", help = "Generate a single password of 9 random digits")
-'''
+
 parser.add_argument("-w", "--words", action="store", help = "Comma seperated keywords to mutate")
 parser.add_argument("-an", "--append-numbering", action="store", help = "Append numbering range at the end of each word mutation (before appending year or common paddings).\nThe LEVEL value represents the minimum number of digits. LEVEL must be >= 1. \nSet to 1 will append range: 1,2,3..100\nSet to 2 will append range: 01,02,03..100 + previous\nSet to 3 will append range: 001,002,003..100 + previous.\n\n", type = int, metavar='LEVEL')
 parser.add_argument("-nl", "--numbering-limit", action="store", help = "Change max numbering limit value of option -an. Default is 50. Must be used with -an.", type = int, metavar='LIMIT')
@@ -154,6 +154,21 @@ mutations_cage = []
 basic_mutations = []
 outfile = args.output if args.output else 'output.txt'
 trans_keys = []
+random_sequence = []
+
+# If the user wants a random alphanumeric sequence, set the selection with appropriate characters
+if not args.words:
+	if args.random_alphanumeric:
+		random_sequence = ["abcdefghijklmnopqrstuvwxyz1234567890"]
+
+	elif args.random_uppercase_alphanumeric:
+		random_sequence = ["ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"]
+
+	elif args.random_uppercase_lowercase_alphanumeric:
+		random_sequence = ["abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"]
+
+	elif args.numbers:
+		random_sequence = ["1234567890"]
 
 transformations = [
 	{'a' : ['@', '4']},
@@ -588,6 +603,17 @@ def main():
 			
 			print(f'\n[{MAIN}Info{END}] Completed! List saved in {outfile}\n')
 	
+	elif args.random_alphanumeric:
+		pass
+
+	elif args.random_uppercase_alphanumeric:
+		pass
+
+	elif args.random_uppercase_lowercase_alphanumeric:
+		pass
+
+	elif args.numbers:
+		pass
 
 if __name__ == '__main__':
 	main()

--- a/psudohash.py
+++ b/psudohash.py
@@ -31,11 +31,13 @@ Usage examples:
 '''
 	)
 
-parser.add_argument("-ra", "--random-alphanumeric", action = "store_true", help = "Generate a single lowercase alphanumeric password")
-parser.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store_true", help = "Generate a single uppercase alphanumeric password")
-parser.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store_true", help = "Generate a single upper- and lowercase alphanumeric password")
+random_group = parser.add_mutually_exclusive_group()
+
+random_group.add_argument("-ra", "--random-alphanumeric", action = "store_true", help = "Generate a single lowercase alphanumeric password")
+random_group.add_argument("-rua", "--random-uppercase-alphanumeric", action = "store_true", help = "Generate a single uppercase alphanumeric password")
+random_group.add_argument("-rula", "--random-uppercase-lowercase-alphanumeric", action = "store_true", help = "Generate a single upper- and lowercase alphanumeric password")
+random_group.add_argument("-n", "--numbers", action = "store_true", help = "Generate a single password of 9 random digits")
 parser.add_argument("-sc", "--special-characters", action = "store_true", help = "Include special characters in the password")
-parser.add_argument("-n", "--numbers", action = "store_true", help = "Generate a single password of 9 random digits")
 
 parser.add_argument("-w", "--words", action="store", help = "Comma seperated keywords to mutate")
 parser.add_argument("-an", "--append-numbering", action="store", help = "Append numbering range at the end of each word mutation (before appending year or common paddings).\nThe LEVEL value represents the minimum number of digits. LEVEL must be >= 1. \nSet to 1 will append range: 1,2,3..100\nSet to 2 will append range: 01,02,03..100 + previous\nSet to 3 will append range: 001,002,003..100 + previous.\n\n", type = int, metavar='LEVEL')


### PR DESCRIPTION
Added flags to generate a single random alphanumeric, uppercase alphanumeric, upper- and lowercase alphanumeric, and solely numeric passwords, with an optional flag for including special characters. The alphanumeric passwords default to length 12 and the numeric defaults to 9, although any number >= 1 can be included as an optional argument with the commands. The script defaults to keyword-based generation and the new commands will not interfere with using keywords in the case that both are included. 