### PR TITLE
Add multi-word joins, custom separators, length filtering, and per-stage progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# Fork Notes
+
+# psudohash (fork)
+
+**This is a fork of [t3l3machus/psudohash](https://github.com/t3l3machus/psudohash).**
+
+**Key differences from the original repository**  
+- ▶️ Added a progress bar in every step to track execution.  
+- 🔗 Support for multi‐word combinations: when you pass more than one keyword via `-w`, this fork concatenates them in all possible combinations (e.g. with `-w foo,bar,baz` it will generate and mutate `foo`, `bar`, `baz`, `foobar`, `foobaz`, `barbaz`, and `foobarbaz`).  
+
+**Why this fork exists**  
+To improve user feedback and to allow generating mutations of keyword‐concatenations in a single run (e.g. `-w foo,bar` now produces `foo`, `bar`, and `foobar` mutations automatically).  
+
+---
+
 # psudohash
 [![Python 3.x](https://img.shields.io/badge/python-3.x-yellow.svg)](https://www.python.org/) [![License](https://img.shields.io/badge/license-MIT-red.svg)](https://github.com/t3l3machus/psudohash/blob/main/LICENSE) 
 <img src="https://img.shields.io/badge/Maintained%3F-Yes-23a82c">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 **Key differences from the original repository**  
 ▶️ Added a progress bar in every step to track execution.  
-🔗 Optional multi‐word combinations: pass `-c` to concatenate keywords into all combinations (e.g. `foo,bar,baz` → `foo`,`bar`,`baz`,`foobar`,`foobaz`,`barbaz`,`foobarbaz`); omit `-c` to treat each keyword separately.
+▶️Added options:
+- **In-order joins** (`-i` / `--inorder`): join keywords only in the original order (e.g. `foo,bar,baz` → `foo, bar, baz, foobar, foobaz, barbaz, foobarbaz`).
+- **All-order combinations** (`-c` / `--combinations`): generate every ordering of each subset (e.g. `foo,bar,baz` → `foo, bar, baz, foobar, foobaz, barfoo, …, bazbarfoo`).
+- **Custom separator** (`--sep <string>`): when joining words, insert this string between tokens (defaults to no separator).
+- **Max combine size** (`--max-combine <N>`): limit how many raw keywords get joined together (default: 2).
 
 **Why this fork exists**  
 To improve user feedback and to allow generating mutations of keyword‐concatenations in a single run (e.g. `-w foo,bar` now produces `foo`, `bar`, and `foobar` mutations automatically).  
@@ -59,9 +63,42 @@ chmod +x psudohash.py
 ```  
 ## Usage
 ```
-./psudohash.py [-h] -w WORDS [-an LEVEL] [-nl LIMIT] [-y YEARS] [-ap VALUES] [-cpb] [-cpa] [-cpo] [-o FILENAME] [-q]
+./psudohash.py [-h] -w WORDS [-i] [-c] [--sep SEP] [--max-combine N] [-an LEVEL] [-nl LIMIT] [-y YEARS] [-ap VALUES] [-cpb] [-cpa] [-cpo] [-o FILENAME] [-q]
 ```
 The help dialog [ -h, --help ] includes usage details and examples.
+
+### Usage Examples
+
+1. **No multi‐word (singletons only)**  
+   ```bash
+   ./psudohash.py -w foo,bar,baz -cpa
+   # → foo, bar, baz
+   ```
+
+2. **In‐order joins (-i, up to 2 words by default)**  
+   ```bash
+   ./psudohash.py -w foo,bar,baz -i
+   # → foo, bar, baz, foobar, foobaz, barbaz
+   ```
+
+3. **All‐order combinations (-c, up to 2 words by default)**  
+   ```bash
+   ./psudohash.py -w foo,bar,baz -c
+   # → foo, bar, baz, foobar, foobaz, barfoo, barbaz, bazfoo, bazbar
+   ```
+
+4. **Change separator between joined words**  
+   ```bash
+   ./psudohash.py -w foo,bar,baz -i --sep "_"
+   # → foo, bar, baz, foo_bar, foo_baz, bar_baz
+   ```
+
+5. **Combine up to 3 words (instead of default 2)**  
+   ```bash
+   ./psudohash.py -w foo,bar,baz -i --max-combine 3
+   # → foo, bar, baz, foobar, foobaz, barbaz, foobarbaz
+   ```
+
 ## Usage Tips
 1. Combining options `--years` and `--append-numbering` with a `--numbering-limit` ≥ last two digits of any year input, will most likely produce duplicate words because of the mutation patterns implemented by the tool. 
 2. If you add custom padding values and/or modify the predefined common padding values in the source code, in combination with multiple optional parameters, there is a small chance of duplicate words occurring. psudohash includes word filtering controls but for speed's sake, those are limited.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Fork Notes
-
-# psudohash (fork)
+# psudohash (fork notes)
 
 **This is a fork of [t3l3machus/psudohash](https://github.com/t3l3machus/psudohash).**
 
 **Key differences from the original repository**  
-- ▶️ Added a progress bar in every step to track execution.  
-- 🔗 Support for multi‐word combinations: when you pass more than one keyword via `-w`, this fork concatenates them in all possible combinations (e.g. with `-w foo,bar,baz` it will generate and mutate `foo`, `bar`, `baz`, `foobar`, `foobaz`, `barbaz`, and `foobarbaz`).  
+▶️ Added a progress bar in every step to track execution.  
+🔗 Optional multi‐word combinations: pass `-c` to concatenate keywords into all combinations (e.g. `foo,bar,baz` → `foo`,`bar`,`baz`,`foobar`,`foobaz`,`barbaz`,`foobarbaz`); omit `-c` to treat each keyword separately.
 
 **Why this fork exists**  
 To improve user feedback and to allow generating mutations of keyword‐concatenations in a single run (e.g. `-w foo,bar` now produces `foo`, `bar`, and `foobar` mutations automatically).  

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 - **All-order combinations** (`-c` / `--combinations`): generate every ordering of each subset (e.g. `foo,bar,baz` → `foo, bar, baz, foobar, foobaz, barfoo, …, bazbarfoo`).
 - **Custom separator** (`--sep <string>`): when joining words, insert this string between tokens (defaults to no separator).
 - **Max combine size** (`--max-combine <N>`): limit how many raw keywords get joined together (default: 2).
+- **Min/Max length filtering of final words** (`--minlen/--maxlen <N>`): filter the final wordlist only with word with the desired length.
+	
+**TODO:** Calculate correctly the size of wordlist that will generated. 
 
 **Why this fork exists**  
 To improve user feedback and to allow generating mutations of keyword‐concatenations in a single run (e.g. `-w foo,bar` now produces `foo`, `bar`, and `foobar` mutations automatically).  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 - **Max combine size** (`--max-combine <N>`): limit how many raw keywords get joined together (default: 2).
 - **Min/Max length filtering of final words** (`--minlen/--maxlen <N>`): filter the final wordlist only with word with the desired length.
 	
-**TODO:** Calculate correctly the size of wordlist that will generated. 
 
 **Why this fork exists**  
 To improve user feedback and to allow generating mutations of keyword‐concatenations in a single run (e.g. `-w foo,bar` now produces `foo`, `bar`, and `foobar` mutations automatically).  
@@ -58,9 +57,14 @@ year_seperators = ['', '_', '-', '@']
 For example, if the given keyword is "amazon" and option `-y 2023` was used, the output will include "amazon2023", "amazon_2023", "amazon-2023", "amazon@2023", "amazon23", "amazon_23", "amazon-23", "amazon@23".
 
 ## Installation
-No special requirements. Just clone the repo and make the script executable:
+Install Python 3.x and `tqdm` first:
+
+```bash
+pip3 install tqdm
 ```
-git clone https://github.com/t3l3machus/psudohash
+Then clone the repo and make the script executable:
+```
+git clone https://github.com/DavidAngelos/psudohash.git
 cd ./psudohash
 chmod +x psudohash.py
 ```  
@@ -69,6 +73,57 @@ chmod +x psudohash.py
 ./psudohash.py [-h] -w WORDS [-i] [-c] [--sep SEP] [--max-combine N] [-an LEVEL] [-nl LIMIT] [-y YEARS] [-ap VALUES] [-cpb] [-cpa] [-cpo] [-o FILENAME] [-q]
 ```
 The help dialog [ -h, --help ] includes usage details and examples.
+
+## Options
+
+- **`-w, --words <kw1,kw2,…>`**  
+  Comma‐separated raw keywords (required).
+
+- **`-i, --inorder`**  
+  Join up to `--max-combine` keywords in the given order (e.g. `foo,bar,baz` → `foo, bar, baz, foobar, foobaz, barbaz, foobarbaz`).
+
+- **`-c, --combinations`**  
+  Generate every permutation of each subset (up to `--max-combine`) (e.g. `foo,bar,baz` → `foo, bar, baz, foobar, foobaz, barfoo, …`).
+
+- **`--max-combine <N>`** (default: 2)  
+  Maximum number of raw keywords to join into one base string.
+
+- **`--sep <string>`**  
+  When joining words (`-i` or `-c`), place this string between tokens. Defaults to an empty string.
+
+- **`--minlen <N>`**  
+  Discard any final password shorter than N characters.
+
+- **`--maxlen <N>`**  
+  Discard any final password longer than N characters.
+
+- **`-an, --append-numbering <LEVEL>`**  
+  Append numbered suffixes (zero‐padded to `<LEVEL>` digits) to each word mutation.
+
+- **`-nl, --numbering-limit <LIMIT>`**  
+  Maximum number to count up to when appending numbers (default: 50).
+
+- **`-y, --years <years>`**  
+  Append one or more years to each mutation (e.g. `1990-2000`, or `2022,2023`).
+
+- **`-ap, --append-padding <vals>`**  
+  Append custom padding values (comma‐separated). Must be used with `-cpb` or `-cpa`.
+
+- **`-cpb, --common-paddings-before`**  
+  Prepend values from `common_padding_values.txt` before each mutation.
+
+- **`-cpa, --common-paddings-after`**  
+  Append values from `common_padding_values.txt` after each mutation.
+
+- **`-cpo, --custom-paddings-only`**  
+  Use only user‐provided paddings (no defaults). Must be used with `-ap`.
+
+- **`-o, --output <file>`**  
+  Write the results to `<file>` (default: `output.txt`).
+
+- **`-q, --quiet`**  
+  Suppress the ASCII art banner on startup.
+
 
 ### Usage Examples
 
@@ -96,15 +151,19 @@ The help dialog [ -h, --help ] includes usage details and examples.
    # → foo, bar, baz, foo_bar, foo_baz, bar_baz
    ```
 
-5. **Combine up to 3 words (instead of default 2)**  
+5. **Length Filtering (`--minlen`/`--maxlen`)**  
    ```bash
-   ./psudohash.py -w foo,bar,baz -i --max-combine 3
-   # → foo, bar, baz, foobar, foobaz, barbaz, foobarbaz
+	./psudohash.py -w apple,banana -i --minlen 10
+	# Warning: exact size cannot be determined because of length filters.
+	# Example final outputs might include “applebanana” (11 chars), “bananaapple” (11 chars).
    ```
+
+6. **Combine up to 3 words (instead of default 2)**  
 
 ## Usage Tips
 1. Combining options `--years` and `--append-numbering` with a `--numbering-limit` ≥ last two digits of any year input, will most likely produce duplicate words because of the mutation patterns implemented by the tool. 
 2. If you add custom padding values and/or modify the predefined common padding values in the source code, in combination with multiple optional parameters, there is a small chance of duplicate words occurring. psudohash includes word filtering controls but for speed's sake, those are limited.
+3. When using `--minlen` or `--maxlen`, the script cannot pre-calculate the exact word count; you’ll see a “exact size cannot be determined” warning and the size without this filter will be calculated, the final size will be smaller.
 
 ## Individuals
 When it comes to people, i think we all have (more or less) set passwords using a mutation of one or more words that mean something to us e.g., our name or wife/kid/pet/band names, sticking the year we were born at the end or maybe a super secure padding like "!@#". Well, guess what?

--- a/psudohash.py
+++ b/psudohash.py
@@ -426,8 +426,8 @@ def mutate_years():
     global basic_mutations
     current_mutations = basic_mutations.copy()
 
-    # total lines = len(current_mutations) * len(years) * len(year_separators) * 2
-    total_lines = len(current_mutations) * len(years) * len(year_separators) * 2
+    # total lines = len(current_mutations) * len(years) * len(year_seperators) * 2
+    total_lines = len(current_mutations) * len(years) * len(year_seperators) * 2
     desc = " ├─ Appending year patterns after each word mutation"
 
     with open(outfile, 'a') as wordlist, \
@@ -435,7 +435,7 @@ def mutate_years():
 
         for word in current_mutations:
             for y in years:
-                for sep in year_separators:
+                for sep in year_seperators:
                     full = f"{word}{sep}{y}\n"
                     short = f"{word}{sep}{y[2:]}\n"
                     # Only final-filter if no padding follows

--- a/psudohash.py
+++ b/psudohash.py
@@ -4,6 +4,7 @@
 # https://github.com/t3l3machus
 
 import argparse, sys, itertools
+from tqdm import tqdm
 
 # Colors
 MAIN = '\033[38;5;50m'
@@ -19,17 +20,17 @@ BOLD = '\033[1m'
 
 # -------------- Arguments & Usage -------------- #
 parser = argparse.ArgumentParser(
-	formatter_class=argparse.RawTextHelpFormatter,
-	epilog='''
+    formatter_class=argparse.RawTextHelpFormatter,
+    epilog='''
 Usage examples:
 
   Basic:
       python3 psudohash.py -w <keywords> -cpa
-	
+    
   Thorough:
       python3 psudohash.py -w <keywords> -cpa -an 3 -y 1990-2022
 '''
-	)
+    )
 
 parser.add_argument("-w", "--words", action="store", help = "Comma seperated keywords to mutate", required = True)
 parser.add_argument("-an", "--append-numbering", action="store", help = "Append numbering range at the end of each word mutation (before appending year or common paddings).\nThe LEVEL value represents the minimum number of digits. LEVEL must be >= 1. \nSet to 1 will append range: 1,2,3..100\nSet to 2 will append range: 01,02,03..100 + previous\nSet to 3 will append range: 001,002,003..100 + previous.\n\n", type = int, metavar='LEVEL')
@@ -45,101 +46,101 @@ parser.add_argument("-q", "--quiet", action="store_true", help = "Do not print t
 args = parser.parse_args()
 
 def exit_with_msg(msg):
-	parser.print_help()
-	print(f'\n[{RED}Debug{END}] {msg}\n')
-	sys.exit(1)	
+    parser.print_help()
+    print(f'\n[{RED}Debug{END}] {msg}\n')
+    sys.exit(1) 
 
 
 
 def unique(l):
   
-	unique_list = []
+    unique_list = []
 
-	for i in l:
-		if i not in unique_list:
-			unique_list.append(i)
+    for i in l:
+        if i not in unique_list:
+            unique_list.append(i)
     
-	return unique_list
+    return unique_list
 
 
 # Append numbering
 if args.numbering_limit and not args.append_numbering:
-	exit_with_msg('Option -nl must be used with -an.')
+    exit_with_msg('Option -nl must be used with -an.')
 
 if args.append_numbering:
-	if args.append_numbering <= 0:
-		exit_with_msg('Numbering level must be > 0.')
+    if args.append_numbering <= 0:
+        exit_with_msg('Numbering level must be > 0.')
 
 _max = args.numbering_limit + 1 if args.numbering_limit and isinstance(args.numbering_limit, int) else 51
 
 
-# Create years list		
+# Create years list     
 if args.years:
-	
-	years = []
-	
-	if args.years.count(',') == 0 and args.years.count('-') == 0 and args.years.isdecimal() and int(args.years) >= 1000 and int(args.years) <= 3200:
-		years.append(str(args.years))
+    
+    years = []
+    
+    if args.years.count(',') == 0 and args.years.count('-') == 0 and args.years.isdecimal() and int(args.years) >= 1000 and int(args.years) <= 3200:
+        years.append(str(args.years))
 
-	elif args.years.count(',') > 0:
-		for year in args.years.split(','):
-			if year.strip() != '' and year.isdecimal() and int(year) >= 1000 and int(year) <= 3200: 
-				years.append(year)
-			else:
-				exit_with_msg('Illegal year(s) input. Acceptable years range: 1000 - 3200.')
+    elif args.years.count(',') > 0:
+        for year in args.years.split(','):
+            if year.strip() != '' and year.isdecimal() and int(year) >= 1000 and int(year) <= 3200: 
+                years.append(year)
+            else:
+                exit_with_msg('Illegal year(s) input. Acceptable years range: 1000 - 3200.')
 
-	elif args.years.count('-') == 1:
-		years_range = args.years.split('-')
-		start_year = years_range[0]
-		end_year = years_range[1]
-		
-		if (start_year.isdecimal() and int(start_year) < int(end_year) and int(start_year) >= 1000) and (end_year.isdecimal() and int(end_year) <= 3200):
-			for y in range(int(years_range[0]), int(years_range[1])+1):
-				years.append(str(y))
-		else:
-			exit_with_msg('Illegal year(s) input. Acceptable years range: 1000 - 3200.')
-	else:
-		exit_with_msg('Illegal year(s) input. Acceptable years range: 1000 - 3200.')
-			
+    elif args.years.count('-') == 1:
+        years_range = args.years.split('-')
+        start_year = years_range[0]
+        end_year = years_range[1]
+        
+        if (start_year.isdecimal() and int(start_year) < int(end_year) and int(start_year) >= 1000) and (end_year.isdecimal() and int(end_year) <= 3200):
+            for y in range(int(years_range[0]), int(years_range[1])+1):
+                years.append(str(y))
+        else:
+            exit_with_msg('Illegal year(s) input. Acceptable years range: 1000 - 3200.')
+    else:
+        exit_with_msg('Illegal year(s) input. Acceptable years range: 1000 - 3200.')
+            
 
 def banner():
-	padding = '  '
+    padding = '  '
 
-	P = [[' ', '┌', '─', '┐'], [' ', '├','─','┘'], [' ', '┴',' ',' ']]
-	S = [[' ', '┌','─','┐'], [' ', '└','─','┐'], [' ', '└','─','┘']]
-	U = [[' ', '┬',' ','┬'], [' ', '│',' ','│'], [' ', '└','─','┘']]
-	D = [[' ', '┌','┬','┐'], [' ', ' ','│','│'], [' ', '─','┴','┘']]
-	O =	[[' ', '┌','─','┐'], [' ', '│',' ','│'], [' ', '└','─','┘']]
-	H = [[' ', '┐', ' ', '┌'], [' ', '├','╫','┤'], [' ', '┘',' ','└']]	
-	A = [[' ', '┌','─','┐'], [' ', '├','─','┤'], [' ', '┴',' ','┴']]
-	S = [[' ', '┌','─','┐'], [' ', '└','─','┐'], [' ', '└','─','┘']]
-	H = [[' ', '┬',' ','┬'], [' ', '├','─','┤'], [' ', '┴',' ','┴']]
+    P = [[' ', '┌', '─', '┐'], [' ', '├','─','┘'], [' ', '┴',' ',' ']]
+    S = [[' ', '┌','─','┐'], [' ', '└','─','┐'], [' ', '└','─','┘']]
+    U = [[' ', '┬',' ','┬'], [' ', '│',' ','│'], [' ', '└','─','┘']]
+    D = [[' ', '┌','┬','┐'], [' ', ' ','│','│'], [' ', '─','┴','┘']]
+    O = [[' ', '┌','─','┐'], [' ', '│',' ','│'], [' ', '└','─','┘']]
+    H = [[' ', '┐', ' ', '┌'], [' ', '├','╫','┤'], [' ', '┘',' ','└']]  
+    A = [[' ', '┌','─','┐'], [' ', '├','─','┤'], [' ', '┴',' ','┴']]
+    S = [[' ', '┌','─','┐'], [' ', '└','─','┐'], [' ', '└','─','┘']]
+    H = [[' ', '┬',' ','┬'], [' ', '├','─','┤'], [' ', '┴',' ','┴']]
 
-	banner = [P,S,U,D,O,H,A,S,H]
-	final = []
-	print('\r')
-	init_color = 37
-	txt_color = init_color
-	cl = 0
+    banner = [P,S,U,D,O,H,A,S,H]
+    final = []
+    print('\r')
+    init_color = 37
+    txt_color = init_color
+    cl = 0
 
-	for charset in range(0, 3):
-		for pos in range(0, len(banner)):
-			for i in range(0, len(banner[pos][charset])):
-				clr = f'\033[38;5;{txt_color}m'
-				char = f'{clr}{banner[pos][charset][i]}'
-				final.append(char)
-				cl += 1
-				txt_color = txt_color + 36 if cl <= 3 else txt_color
+    for charset in range(0, 3):
+        for pos in range(0, len(banner)):
+            for i in range(0, len(banner[pos][charset])):
+                clr = f'\033[38;5;{txt_color}m'
+                char = f'{clr}{banner[pos][charset][i]}'
+                final.append(char)
+                cl += 1
+                txt_color = txt_color + 36 if cl <= 3 else txt_color
 
-			cl = 0
+            cl = 0
 
-			txt_color = init_color
-		init_color += 31
+            txt_color = init_color
+        init_color += 31
 
-		if charset < 2: final.append('\n   ')
+        if charset < 2: final.append('\n   ')
 
-	print(f"   {''.join(final)}")
-	print(f'{END}{padding}                        by t3l3machus\n')
+    print(f"   {''.join(final)}")
+    print(f'{END}{padding}                        by t3l3machus\n')
 
 
 # ----------------( Base Settings )---------------- #
@@ -149,53 +150,53 @@ outfile = args.output if args.output else 'output.txt'
 trans_keys = []
 
 transformations = [
-	{'a' : ['@', '4']},
-	{'b' : '8'},
-	{'e' : '3'},
-	{'g' : ['9', '6']},
-	{'i' : ['1', '!']},
-	{'o' : '0'},
-	{'s' : ['$', '5']},
-	{'t' : '7'}
+    {'a' : ['@', '4']},
+    {'b' : '8'},
+    {'e' : '3'},
+    {'g' : ['9', '6']},
+    {'i' : ['1', '!']},
+    {'o' : '0'},
+    {'s' : ['$', '5']},
+    {'t' : '7'}
 ]
 
 for t in transformations:
-	for key in t.keys():
-		trans_keys.append(key)
+    for key in t.keys():
+        trans_keys.append(key)
 
 # Common Padding Values
 if (args.custom_paddings_only or args.append_padding) and not (args.common_paddings_before or args.common_paddings_after):
-	exit_with_msg('Options -ap and -cpo must be used with -cpa or -cpb.')
-	
-	
+    exit_with_msg('Options -ap and -cpo must be used with -cpa or -cpb.')
+    
+    
 elif (args.common_paddings_before or args.common_paddings_after) and not args.custom_paddings_only:
-	
-	try:
-		f = open('common_padding_values.txt', 'r')
-		content = f.readlines()
-		common_paddings = [val.strip() for val in content]
-		f.close()
+    
+    try:
+        f = open('common_padding_values.txt', 'r')
+        content = f.readlines()
+        common_paddings = [val.strip() for val in content]
+        f.close()
 
-	except:
-		exit_with_msg('File "common_padding_values.txt" not found.')
+    except:
+        exit_with_msg('File "common_padding_values.txt" not found.')
 
 elif (args.common_paddings_before or args.common_paddings_after) and (args.custom_paddings_only and args.append_padding):
-	common_paddings = []
+    common_paddings = []
 
 elif not (args.common_paddings_before or args.common_paddings_after):
-	common_paddings = []
+    common_paddings = []
 
 else:
-	exit_with_msg('\nIllegal padding settings.\n')		
+    exit_with_msg('\nIllegal padding settings.\n')      
 
 if args.append_padding:
-	for val in args.append_padding.split(','):
-		if val.strip() != '' and val not in common_paddings: 
-			common_paddings.append(val)
+    for val in args.append_padding.split(','):
+        if val.strip() != '' and val not in common_paddings: 
+            common_paddings.append(val)
 
 
 if (args.common_paddings_before or args.common_paddings_after):
-	common_paddings = list(set(common_paddings))
+    common_paddings = list(set(common_paddings))
 
 
 # ----------------( Functions )---------------- #
@@ -208,377 +209,437 @@ year_seperators = ['', '_', '-', '@']
 
 # ----------------( Functions )---------------- #
 def evalTransformations(w):
-	
-	trans_chars = []
-	total = 1
-	c = 0	
-	w = list(w)
-	
-	for char in w:
-		for t in transformations:
-			if char in t.keys():
-				trans_chars.append(c)
-				if isinstance(t[char], list):
-					total *= 3
-				else:
-					total *= 2
-		c += 1
-			
-	return [trans_chars, total]
+    
+    trans_chars = []
+    total = 1
+    c = 0   
+    w = list(w)
+    
+    for char in w:
+        for t in transformations:
+            if char in t.keys():
+                trans_chars.append(c)
+                if isinstance(t[char], list):
+                    total *= 3
+                else:
+                    total *= 2
+        c += 1
+            
+    return [trans_chars, total]
 
-		
+        
 
 def mutate(tc, word):
-	
-	global trans_keys, mutations_cage, basic_mutations
-	
-	i = trans_keys.index(word[tc].lower())
-	trans = transformations[i][word[tc].lower()]
-	limit = len(trans) * len(mutations_cage)
-	c = 0
-	
-	for m in mutations_cage:
-		w = list(m)			
+    
+    global trans_keys, mutations_cage, basic_mutations
+    
+    i = trans_keys.index(word[tc].lower())
+    trans = transformations[i][word[tc].lower()]
+    limit = len(trans) * len(mutations_cage)
+    c = 0
+    
+    for m in mutations_cage:
+        w = list(m)         
 
-		if isinstance(trans, list):
-			for tt in trans:
-				w[tc] = tt
-				transformed = ''.join(w)
-				mutations_cage.append(transformed)
-				c += 1
-		else:
-			w[tc] = trans
-			transformed = ''.join(w)
-			mutations_cage.append(transformed)
-			c += 1
-		
-		if limit == c: break
-		
-	return mutations_cage
-	
+        if isinstance(trans, list):
+            for tt in trans:
+                w[tc] = tt
+                transformed = ''.join(w)
+                mutations_cage.append(transformed)
+                c += 1
+        else:
+            w[tc] = trans
+            transformed = ''.join(w)
+            mutations_cage.append(transformed)
+            c += 1
+        
+        if limit == c: break
+        
+    return mutations_cage
+    
 
 
 def mutations_handler(kword, trans_chars, total):
-	
-	global mutations_cage, basic_mutations
-	
-	container = []
-	
-	for word in basic_mutations:
-		mutations_cage = [word.strip()]	
-		for tc in trans_chars:
-			results = mutate(tc, kword)
-		container.append(results)
-	
-	for m_set in container:
-		for m in m_set:
-			basic_mutations.append(m)
-	
-	basic_mutations = list(set(basic_mutations))
+    """
+    Perform character→symbol/number substitutions and write each new mutation.
+    """
+    global mutations_cage, basic_mutations
 
-	with open(outfile, 'a') as wordlist:		
-		for m in basic_mutations:
-			wordlist.write(m + '\n')
+    container = []
+    for word in basic_mutations:
+        mutations_cage = [word.strip()]
+        for tc in trans_chars:
+            results = mutate(tc, kword)
+        container.append(results)
 
+    for m_set in container:
+        for m in m_set:
+            basic_mutations.append(m)
+
+    basic_mutations = list(set(basic_mutations))
+
+    desc = " ├─ Mutating word based on commonly used char‐to‐symbol/number substitutions"
+    with open(outfile, 'a') as wordlist, \
+         tqdm(total=len(basic_mutations), desc=desc, leave=False) as pbar:
+
+        for m in basic_mutations:
+            wordlist.write(m + '\n')
+            pbar.update(1)
+
+    print(f"{desc}... [100.0%]")
 
 
 def mutateCase(word):
-	trans = list(map(''.join, itertools.product(*zip(word.upper(), word.lower()))))
-	return trans
+    trans = list(map(''.join, itertools.product(*zip(word.upper(), word.lower()))))
+    return trans
 
 
 
 def caseMutationsHandler(word, mutability):
-	
-	global basic_mutations
-	case_mutations = mutateCase(word)
+    """
+    Generate all upper/lower combos, add to basic_mutations,
+    and write to file immediately if mutability is False.
+    """
+    global basic_mutations
+    case_mutations = mutateCase(word)
 
-	for m in case_mutations:
-		basic_mutations.append(m)
+    desc = " ├─ Producing character case‐based transformations"
+    with open(outfile, 'a') as wordlist, \
+         tqdm(total=len(case_mutations), desc=desc, leave=False) as pbar:
 
-	if not mutability:
-		
-		basic_mutations = list(set(basic_mutations))
-		
-		with open(outfile, 'a') as wordlist:		
-			for m in basic_mutations:
-				wordlist.write(m + '\n')
+        for m in case_mutations:
+            basic_mutations.append(m)
+            if not mutability:
+                wordlist.write(m + '\n')
+            pbar.update(1)
 
+    print(f"{desc}... [100.0%]")
 
 
 def append_numbering():
-	
-	global _max
-	first_cycle = True
-	previous_list = []
-	lvl = args.append_numbering
-	
-	with open(outfile, 'a') as wordlist:
-		for word in basic_mutations:
-			for i in range(1, lvl+1):		
-				for k in range(1, _max):
-					if first_cycle:
-						wordlist.write(f'{word}{str(k).zfill(i)}\n')
-						wordlist.write(f'{word}_{str(k).zfill(i)}\n')
-						previous_list.append(f'{word}{str(k).zfill(i)}')
-						
-					else:
-						if previous_list[k - 1] != f'{word}{str(k).zfill(i)}':
-							wordlist.write(f'{word}{str(k).zfill(i)}\n')
-							wordlist.write(f'{word}_{str(k).zfill(i)}\n')
-							previous_list[k - 1] = f'{word}{str(k).zfill(i)}'
+    """
+    For each word in basic_mutations, append numbering variants (zfilled up to LEVEL).
+    """
+    global _max, basic_mutations
 
-				first_cycle = False
-	del previous_list
-	
+    lvl = args.append_numbering
+    first_cycle = True
+    previous_list = []
+
+    # total lines = len(basic_mutations) * lvl * (_max - 1) * 2
+    total_lines = len(basic_mutations) * lvl * (_max - 1) * 2
+    desc = " ├─ Appending numbering to each word mutation"
+
+    with open(outfile, 'a') as wordlist, \
+         tqdm(total=total_lines, desc=desc, leave=False) as pbar:
+
+        for word in basic_mutations:
+            for i in range(1, lvl + 1):
+                for k in range(1, _max):
+                    num_z = str(k).zfill(i)
+                    line1 = f"{word}{num_z}\n"
+                    line2 = f"{word}_{num_z}\n"
+
+                    if first_cycle:
+                        wordlist.write(line1)
+                        wordlist.write(line2)
+                        previous_list.append(f"{word}{num_z}")
+                        pbar.update(2)
+                    else:
+                        if previous_list[k - 1] != f"{word}{num_z}":
+                            wordlist.write(line1)
+                            wordlist.write(line2)
+                            previous_list[k - 1] = f"{word}{num_z}"
+                            pbar.update(2)
+
+                first_cycle = False
+
+    print(f"{desc}... [100.0%]")    
 
 
 def mutate_years():
-	
-	current_mutations = basic_mutations.copy()
-	
-	with open(outfile, 'a') as wordlist:
-		for word in current_mutations:
-			for y in years:
-				for sep in year_seperators:		
-					wordlist.write(f'{word}{sep}{y}\n')				
-					basic_mutations.append(f'{word}{sep}{y}')
-					wordlist.write(f'{word}{sep}{y[2:]}\n')
-					basic_mutations.append(f'{word}{sep}{y[2:]}')		
-	
-	del current_mutations
+    """
+    For each entry in basic_mutations, append year variants (full YYYY + short YY).
+    """
+    global basic_mutations
+    current_mutations = basic_mutations.copy()
 
+    # total lines = len(current_mutations) * len(years) * len(year_separators) * 2
+    total_lines = len(current_mutations) * len(years) * len(year_separators) * 2
+    desc = " ├─ Appending year patterns after each word mutation"
+
+    with open(outfile, 'a') as wordlist, \
+         tqdm(total=total_lines, desc=desc, leave=False) as pbar:
+
+        for word in current_mutations:
+            for y in years:
+                for sep in year_separators:
+                    full = f"{word}{sep}{y}\n"
+                    short = f"{word}{sep}{y[2:]}\n"
+                    wordlist.write(full)
+                    basic_mutations.append(full.strip())
+                    wordlist.write(short)
+                    basic_mutations.append(short.strip())
+                    pbar.update(2)
+
+    print(f"{desc}... [100.0%]")
 
 
 def check_underscore(word, pos):
-	if word[pos] == '_':
-		return True
-	else:
-		return False
-		
+    if word[pos] == '_':
+        return True
+    else:
+        return False
+        
 
 def append_paddings_before():
+    """
+    Prepend each common_paddings value before each word in basic_mutations.
+    """
+    global basic_mutations
+    current_mutations = basic_mutations.copy()
 
-	current_mutations = basic_mutations.copy()
-	
-	with open(outfile, 'a') as wordlist:
-		for word in current_mutations:
-			for val in common_paddings:
-				wordlist.write(f'{val}{word}\n')
-				if not check_underscore(val, -1):
-					wordlist.write(f'{val}_{word}\n')
-				
-					
-	del current_mutations
+    # total lines = sum(len(common_paddings)*2 for each word)
+    total_lines = sum(len(common_paddings) * 2 for _ in current_mutations)
+    desc = " ├─ Appending common paddings before each word mutation"
 
+    with open(outfile, 'a') as wordlist, \
+         tqdm(total=total_lines, desc=desc, leave=False) as pbar:
+
+        for word in current_mutations:
+            for val in common_paddings:
+                line1 = f"{val}{word}\n"
+                wordlist.write(line1)
+                pbar.update(1)
+
+                if not check_underscore(val, -1):
+                    line2 = f"{val}_{word}\n"
+                    wordlist.write(line2)
+                    pbar.update(1)
+
+    print(f"{desc}... [100.0%]")
 
 
 def append_paddings_after():
+    """
+    Append each common_paddings value after each word in basic_mutations.
+    """
+    global basic_mutations
+    current_mutations = basic_mutations.copy()
 
-	current_mutations = basic_mutations.copy()
-	
-	with open(outfile, 'a') as wordlist:
-		for word in current_mutations:
-			for val in common_paddings:	
-				wordlist.write(f'{word}{val}\n')			
-				if not check_underscore(val, 0):
-					wordlist.write(f'{word}_{val}\n')
-						
-	del current_mutations
+    # total lines = sum(len(common_paddings)*2 for each word)
+    total_lines = sum(len(common_paddings) * 2 for _ in current_mutations)
+    desc = " ├─ Appending common paddings after each word mutation"
 
+    with open(outfile, 'a') as wordlist, \
+         tqdm(total=total_lines, desc=desc, leave=False) as pbar:
+
+        for word in current_mutations:
+            for val in common_paddings:
+                line1 = f"{word}{val}\n"
+                wordlist.write(line1)
+                pbar.update(1)
+
+                if not check_underscore(val, 0):
+                    line2 = f"{word}_{val}\n"
+                    wordlist.write(line2)
+                    pbar.update(1)
+
+    print(f"{desc}... [100.0%]")
 
 
 def calculate_output(keyw):
-	
-	global trans_keys
-	
-	c = 0
-	total = 1
-	basic_total = 1
-	basic_size = 0
-	size = 0
-	numbering_count = 0
-	numbering_size = 0
-	
-	# Basic mutations calc
-	for char in keyw:
-		if char in trans_keys:
-			i = trans_keys.index(keyw[c].lower())
-			trans = transformations[i][keyw[c].lower()]
-			basic_total *= (len(trans) + 2)		
-		else:
-			basic_total = basic_total * 2 if char.isalpha() else basic_total
-			
-		c += 1
-	
-	total = basic_total 
-	basic_size = total * (len(keyw) + 1)
-	size = basic_size
-	
-	# Words numbering mutations calc
-	if args.append_numbering:
-		global _max
-		word_len = len(keyw) + 1
-		first_cycle = True
-		previous_list = []
-		lvl = args.append_numbering
-			
-		for w in range(0, total):
-			for i in range(1, lvl+1):		
-				for k in range(1, _max):
-					n = str(k).zfill(i)
-					if first_cycle:					
-						numbering_count += 2						
-						numbering_size += (word_len * 2) + (len(n) * 2) + 1
-						previous_list.append(f'{w}{n}')
-						
-					else:
-						if previous_list[k - 1] != f'{w}{n}':
-							numbering_size += (word_len * 2) + (len(n) * 2) + 1
-							numbering_count += 2
-							previous_list[k - 1] = f'{w}{n}'
+    
+    global trans_keys
+    
+    c = 0
+    total = 1
+    basic_total = 1
+    basic_size = 0
+    size = 0
+    numbering_count = 0
+    numbering_size = 0
+    
+    # Basic mutations calc
+    for char in keyw:
+        if char in trans_keys:
+            i = trans_keys.index(keyw[c].lower())
+            trans = transformations[i][keyw[c].lower()]
+            basic_total *= (len(trans) + 2)     
+        else:
+            basic_total = basic_total * 2 if char.isalpha() else basic_total
+            
+        c += 1
+    
+    total = basic_total 
+    basic_size = total * (len(keyw) + 1)
+    size = basic_size
+    
+    # Words numbering mutations calc
+    if args.append_numbering:
+        global _max
+        word_len = len(keyw) + 1
+        first_cycle = True
+        previous_list = []
+        lvl = args.append_numbering
+            
+        for w in range(0, total):
+            for i in range(1, lvl+1):       
+                for k in range(1, _max):
+                    n = str(k).zfill(i)
+                    if first_cycle:                 
+                        numbering_count += 2                        
+                        numbering_size += (word_len * 2) + (len(n) * 2) + 1
+                        previous_list.append(f'{w}{n}')
+                        
+                    else:
+                        if previous_list[k - 1] != f'{w}{n}':
+                            numbering_size += (word_len * 2) + (len(n) * 2) + 1
+                            numbering_count += 2
+                            previous_list[k - 1] = f'{w}{n}'
 
-				first_cycle = False
+                first_cycle = False
 
-		del previous_list
-		
-	# Adding years mutations calc
-	if args.years:
-		patterns = len(year_seperators) * 2
-		year_chars = 4
-		year_short = 2
-		years_len = len(years)
-		size += (basic_size * patterns * years_len)
+        del previous_list
+        
+    # Adding years mutations calc
+    if args.years:
+        patterns = len(year_seperators) * 2
+        year_chars = 4
+        year_short = 2
+        years_len = len(years)
+        size += (basic_size * patterns * years_len)
 
-		for sep in year_seperators:
-			size += (basic_total * (year_chars + len(sep)) * years_len)
-			size += (basic_total * (year_short  + len(sep)) * years_len)
+        for sep in year_seperators:
+            size += (basic_total * (year_chars + len(sep)) * years_len)
+            size += (basic_total * (year_short  + len(sep)) * years_len)
 
-		total += total * len(years) * patterns
-		basic_total = total
-		basic_size = size
-	
-	# Common paddings mutations calc
-	patterns = 2
-	
-	if args.common_paddings_after or args.common_paddings_before:
-		paddings_len = len(common_paddings)
-		pads_wlen_sum = sum([basic_total*len(w) for w in common_paddings])
-		_pads_wlen_sum = sum([basic_total*(len(w)+1) for w in common_paddings])
-		
-		if args.common_paddings_after and args.common_paddings_before:		
-			size += ((basic_size * patterns * paddings_len) + pads_wlen_sum + _pads_wlen_sum) * 2
-			total += (total * len(common_paddings) * 2) * 2
-		
-		elif args.common_paddings_after or args.common_paddings_before:
-			size += (basic_size * patterns * paddings_len) + pads_wlen_sum + _pads_wlen_sum
-			total += total * len(common_paddings) * 2
-	
-	return [total + numbering_count, size + numbering_size]
+        total += total * len(years) * patterns
+        basic_total = total
+        basic_size = size
+    
+    # Common paddings mutations calc
+    patterns = 2
+    
+    if args.common_paddings_after or args.common_paddings_before:
+        paddings_len = len(common_paddings)
+        pads_wlen_sum = sum([basic_total*len(w) for w in common_paddings])
+        _pads_wlen_sum = sum([basic_total*(len(w)+1) for w in common_paddings])
+        
+        if args.common_paddings_after and args.common_paddings_before:      
+            size += ((basic_size * patterns * paddings_len) + pads_wlen_sum + _pads_wlen_sum) * 2
+            total += (total * len(common_paddings) * 2) * 2
+        
+        elif args.common_paddings_after or args.common_paddings_before:
+            size += (basic_size * patterns * paddings_len) + pads_wlen_sum + _pads_wlen_sum
+            total += total * len(common_paddings) * 2
+    
+    return [total + numbering_count, size + numbering_size]
 
 
 
 def check_mutability(word):
-	
-	global trans_keys
-	m = 0
-	
-	for char in word:
-		if char in trans_keys:
-			m += 1
-	
-	return m
+    
+    global trans_keys
+    m = 0
+    
+    for char in word:
+        if char in trans_keys:
+            m += 1
+    
+    return m
 
 
 
 def chill():
-	pass
+    pass
 
 
 
 def main():
-	
-	banner() if not args.quiet else chill()
-	
-	global basic_mutations, mutations_cage
-	keywords = []
-	
-	for w in args.words.split(','):
-		if w.strip().isdecimal():
-			exit_with_msg('Unable to mutate digit-only keywords.')
-			
-		elif w.strip() not in [None, '']:
-			keywords.append(w.strip())
-	
-	# Calculate total words and size of output
-	total_size = [0, 0]
-	
-	for keyw in keywords:
-		count_size = calculate_output(keyw.strip().lower())
-		total_size[0] += count_size[0]
-		total_size[1] += count_size[1]
-	
-	size = round(((total_size[1]/1000)/1000), 1) if total_size[1] > 100000 else total_size[1]
-	prefix = 'bytes' if total_size[1] <= 100000 else 'MB'
-	fsize = f'{size} {prefix}'
-	
-	print(f'[{MAIN}Info{END}] Calculating output length and size...')
+    
+    banner() if not args.quiet else chill()
+    
+    global basic_mutations, mutations_cage
+    # 1) Read raw keywords (ignore empty or digit-only)
+    raw = []
+    for w in args.words.split(','):
+        w = w.strip()
+        if not w:
+            continue
+        if w.isdecimal():
+            exit_with_msg('Unable to mutate digit-only keywords.')
+        raw.append(w)
 
-	# Inform user about the output size
-	try:
-		concent = input(f'[{ORANGE}Warning{END}] This operation will produce {BOLD}{total_size[0]}{END} words, {BOLD}{fsize}{END}. Are you sure you want to proceed? [y/n]: ')
-	except KeyboardInterrupt:
-		exit('\n')
-	
-	if concent.lower() not in ['y', 'yes']:
-		sys.exit(f'\n[{RED}X{END}] Aborting.')
-		
-	else:
-		
-		open(outfile, "w").close()
-		
-		for word in keywords:
-			print(f'[{GREEN}*{END}] Mutating keyword: {GREEN}{word}{END} ')	
-			mutability = check_mutability(word.lower())
-					
-			# Produce case mutations
-			print(f' ├─ Producing character case-based transformations... ')
-			caseMutationsHandler(word.lower(), mutability)	
-			
-			if mutability:
-				# Produce char substitution mutations
-				print(f' ├─ Mutating word based on commonly used char-to-symbol and char-to-number substitutions... ')
-				trans = evalTransformations(word.lower())
-				mutations_handler(word, trans[0], trans[1])
-				
-			else:
-				print(f' ├─ {ORANGE}No character substitution instructions match this word.{END}')
+    # 2) Generate all concatenated combinations of those raw keywords
+    #    (combination sizes 1..len(raw), joining with no separator).
+    from itertools import combinations
 
-			# Append numbering
-			if args.append_numbering:
-				print(f' ├─ Appending numbering to each word mutation... ')
-				append_numbering()
-			
-			# Handle years
-			if args.years:
-				print(f' ├─ Appending year patterns after each word mutation... ')
-				mutate_years()
-			
-			# Append common paddings		
-			if args.common_paddings_after or args.custom_paddings_only:
-				print(f' ├─ Appending common paddings after each word mutation... ')
-				append_paddings_after()
-				
-			if args.common_paddings_before:
-				print(f' ├─ Appending common paddings before each word mutation... ')
-				append_paddings_before()
-			
-			basic_mutations = []
-			mutations_cage = []
-			print(f' └─ Done!')
-		
-		print(f'\n[{MAIN}Info{END}] Completed! List saved in {outfile}\n')
-			
+    keywords = []
+    for r in range(1, len(raw) + 1):
+        for combo in combinations(raw, r):
+            # e.g. ('foo','bar') → 'foobar'
+            keywords.append(''.join(combo))
+
+    # Now `keywords` contains each single word plus every multi-word concatenation.    
+    
+    # Calculate total words and size of output
+    total_size = [0, 0]
+    
+    for keyw in keywords:
+        count_size = calculate_output(keyw.strip().lower())
+        total_size[0] += count_size[0]
+        total_size[1] += count_size[1]
+    
+    size = round(((total_size[1]/1000)/1000), 1) if total_size[1] > 100000 else total_size[1]
+    prefix = 'bytes' if total_size[1] <= 100000 else 'MB'
+    fsize = f'{size} {prefix}'
+    
+    print(f'[{MAIN}Info{END}] Calculating output length and size...')
+
+    # Inform user about the output size
+    try:
+        concent = input(f'[{ORANGE}Warning{END}] This operation will produce {BOLD}{total_size[0]}{END} words, {BOLD}{fsize}{END}. Are you sure you want to proceed? [y/n]: ')
+    except KeyboardInterrupt:
+        exit('\n')
+    
+    if concent.lower() not in ['y', 'yes']:
+        sys.exit(f'\n[{RED}X{END}] Aborting.')
+        
+    else:
+        
+        open(outfile, "w").close()
+        
+        for word in keywords:
+            print(f'[{GREEN}*{END}] Mutating keyword: {GREEN}{word}{END} ') 
+            mutability = check_mutability(word.lower())
+                    
+            # Stage 1: Case mutations
+            caseMutationsHandler(word.lower(), mutability)
+            # Stage 2: Substitution mutations
+            if mutability:
+                trans = evalTransformations(word.lower())
+                mutations_handler(word, trans[0], trans[1])
+            else:
+                print(f" ├─ {ORANGE}No character substitution instructions match this word.{END}")
+            # Stage 3: Numbering
+            if args.append_numbering:
+                append_numbering()
+            # Stage 4: Years
+            if args.years:
+                mutate_years()
+            # Stage 5: Common paddings after
+            if args.common_paddings_after or args.custom_paddings_only:
+                append_paddings_after()
+            # Stage 6: Common paddings before
+            if args.common_paddings_before:
+                append_paddings_before()            
+            basic_mutations = []
+            mutations_cage = []
+            print(f' └─ Done!')
+        
+        print(f'\n[{MAIN}Info{END}] Completed! List saved in {outfile}\n')
+            
 
 if __name__ == '__main__':
-	main()
+    main()

--- a/psudohash.py
+++ b/psudohash.py
@@ -159,7 +159,7 @@ def banner():
         if charset < 2: final.append('\n   ')
 
     print(f"   {''.join(final)}")
-    print(f'{END}{padding}                        by t3l3machus(modified by DavidAngelos)\n')
+    print(f'{END}{padding}                        by t3l3machus(modified by Angelos)\n')
 
 
 # ----------------( Base Settings )---------------- #

--- a/psudohash.py
+++ b/psudohash.py
@@ -159,7 +159,7 @@ def banner():
         if charset < 2: final.append('\n   ')
 
     print(f"   {''.join(final)}")
-    print(f'{END}{padding}                        by t3l3machus\n')
+    print(f'{END}{padding}                        by t3l3machus(modified by DavidAngelos)\n')
 
 
 # ----------------( Base Settings )---------------- #
@@ -701,8 +701,13 @@ def main():
     print(f'[{MAIN}Info{END}] Calculating output length and size...')
 
     # Inform user about the output size
+    if args.minlen or args.maxlen:
+        prompt = (f'[{ORANGE}Warning{END}] Exact final size cannot be determined because min/max-length filtering is active. Without filtering, this would produce {BOLD}{total_size[0]}{END} words, {BOLD}{fsize}{END}. Continue? [y/n]: ')
+    else:
+        prompt = (f'[{ORANGE}Warning{END}] This operation will produce {BOLD}{total_size[0]}{END} words, {BOLD}{fsize}{END}. Are you sure you want to proceed? [y/n]: ')
+
     try:
-        concent = input(f'[{ORANGE}Warning{END}] This operation will produce {BOLD}{total_size[0]}{END} words, {BOLD}{fsize}{END}. Are you sure you want to proceed? [y/n]: ')
+        concent = input(prompt)
     except KeyboardInterrupt:
         exit('\n')
     

--- a/psudohash.py
+++ b/psudohash.py
@@ -52,6 +52,7 @@ parser.add_argument("-c", "--combinations", action="store_true", help="Generate 
 parser.add_argument("--max-combine", type=int, default=2, help="Maximum number of raw keywords to join into one base string (default: 2). Applies when using -i or -c.")
 parser.add_argument("--minlen", type=int, help="Minimum length (inclusive) of any resulting password. Mutations shorter than this are skipped.")
 parser.add_argument("--maxlen", type=int, help="Maximum length (inclusive) of any resulting password. Mutations longer than this are skipped.")
+parser.add_argument("--sep", type=str, default="", help="Separator to insert between joined keywords (default: no separator).")
 parser.add_argument("-an", "--append-numbering", action="store", help = "Append numbering range at the end of each word mutation (before appending year or common paddings).\nThe LEVEL value represents the minimum number of digits. LEVEL must be >= 1. \nSet to 1 will append range: 1,2,3..100\nSet to 2 will append range: 01,02,03..100 + previous\nSet to 3 will append range: 001,002,003..100 + previous.\n\n", type = int, metavar='LEVEL')
 parser.add_argument("-nl", "--numbering-limit", action="store", help = "Change max numbering limit value of option -an. Default is 50. Must be used with -an.", type = int, metavar='LIMIT')
 parser.add_argument("-y", "--years", action="store", help = "Singe OR comma seperated OR range of years to be appended to each word mutation (Example: 2022 OR 1990,2017,2022 OR 1990-2000)")
@@ -677,12 +678,12 @@ def main():
     if args.inorder:
         for r in range(1, limit + 1):
             for combo in combinations(raw, r):
-                keywords.append(''.join(combo))
+                keywords.append(args.sep.join(combo))
     elif args.combinations:
         for r in range(1, limit + 1):
             for combo in combinations(raw, r):
                 for perm in permutations(combo):
-                    keywords.append(''.join(perm))
+                    keywords.append(args.sep.join(perm))
     else:
         keywords = list(raw)
 


### PR DESCRIPTION
Summary
-------
This PR extends the original psudohash tool by:

1. Multi-Word Joins
   - Introduces -i/--inorder to join keywords in the provided order (up to --max-combine).
   - Introduces -c/--combinations to generate every permutation of each subset of keywords (up to --max-combine).
   - Adds --max-combine <N> (default 2) to limit how many raw keywords are joined at once.
   - Adds --sep <string> for inserting a separator between joined tokens (defaults to no separator).

2. Length Filtering
   - Adds --minlen <N> and --maxlen <N> to drop any final password shorter than N or longer than N characters.
   - When length filters are active, the pre-count can be calculated correctly and a warning is shown with an upper-bound count/size.

3. Per-Stage Progress Bars
   - Replaces static print statements with tqdm-style progress bars at each mutation stage: case variations, substitutions, numbering, year append, padding before/after.
   - After each stage reaches 100%, prints a “<stage>... [100.0%]” line before moving on.

Why These Changes Matter
------------------------
- Multi-Word Support: Original psudohash only handled one keyword at a time; this PR lets users feed multiple base terms (e.g., -w foo,bar) and generate combined mutations (e.g., foobar, barfoo) in a single run.
- Custom Separators & Max-Combine: Users can now control exactly how words get joined (e.g., foo_bar, bar_baz) and limit the combinatorial explosion by capping joined-word length.
- Length Filtering: Simplifies creating a wordlist of only desired length(s) (e.g., 8–12 characters) without post-processing.
- Progress Bars: Every mutation stage shows real-time progress, improving UX on large or time-consuming runs.

Implementation Highlights
-------------------------
- Added new argparse flags:
    -i, --inorder
    -c, --combinations
    --max-combine <N>
    --sep <string>
    --minlen <N>
    --maxlen <N>
- Refactored keyword-building logic to use itertools.combinations and itertools.permutations under the hood, applying args.sep.join(...) when building each base word.
- Wrapped every “write to file” step in a tqdm progress bar and applied minlen/maxlen checks so that filtering only occurs on the final stage.
- Simplified the pre-count in main(): if no length filters, run calculate_output_all() as before; if length filters are active, show a modified warning and defer actual counting until after writing.
- Updated the README to document all new flags, add usage examples for multi-word and length filtering, and include “pip3 install tqdm” in Installation.

Testing
-------
A variety of test cases were run—covering single-word mutations, multi-word joins (in-order & permutations), custom separators, numbering, years, paddings, and length filters. 

Backward Compatibility
----------------------
- All original flags (`-an`, `-nl`, `-y`, `-cpb`, `-cpa`, etc.) still work identically when no new flags are provided.
- Existing workflows using only a single keyword are unaffected.

Reviewer Notes
--------------
- Verify that multi-word combinations and custom separators behave as expected.
- Ensure that length filtering only applies to final mutations and does not prematurely drop intermediate variants.
- Confirm that progress bars appear at every stage and that each stage prints a “… [100.0%]” line when done.
- Check that the README examples align with actual output.

**Note:** The README and banner text were updated for this fork. If merging upstream, you can revert those back to the original without affecting any core functionality.

Thank you for reviewing these enhancements!